### PR TITLE
Fix custom start time duration display & stopped record end time when using --at

### DIFF
--- a/src/better_timetagger_cli/cli/start_cmd.py
+++ b/src/better_timetagger_cli/cli/start_cmd.py
@@ -103,7 +103,7 @@ def start_cmd(
 
         # Stop running tasks, unless in 'keep' mode
         if not keep:
-            r["t2"] = now
+            r["t2"] = start_t
             r["mt"] = now
             stopped_records.append(r)
             running_records.remove(r)


### PR DESCRIPTION
Previously, running `t start --at ...` would always...

- display the duration of the current record as `0`, even when the `--at` argument would be in the past.
- stop currently running records `now`, not at the provided `--at` time.

This PR fixes these two issues.