### PR TITLE
Add new `--utc` parameter to the `export` command

### DIFF
--- a/src/better_timetagger_cli/cli/export_cmd.py
+++ b/src/better_timetagger_cli/cli/export_cmd.py
@@ -29,6 +29,13 @@ from better_timetagger_cli.lib.records import round_records
     help="Output file. If not specified, print the output to stdout.",
 )
 @click.option(
+    "-u",
+    "--utc",
+    "utc",
+    is_flag=True,
+    help="Export timestamps in UTC instead of local time.",
+)
+@click.option(
     "-s",
     "--start",
     type=click.STRING,
@@ -70,6 +77,7 @@ from better_timetagger_cli.lib.records import round_records
 )
 def export_cmd(
     tags: list[str],
+    utc: bool,
     file: click.File | None,
     start: str | None,
     end: str | None,
@@ -118,7 +126,7 @@ def export_cmd(
     if round:
         records = round_records(records, round)
 
-    csv = records_to_csv(records)
+    csv = records_to_csv(records, utc=utc)
 
     click.echo(csv, file=file)  # type: ignore[arg-type]
 

--- a/tests/test_lib/test_csv/test_records_to_csv.py
+++ b/tests/test_lib/test_csv/test_records_to_csv.py
@@ -1,3 +1,8 @@
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
 from better_timetagger_cli.lib.csv import records_to_csv
 
 
@@ -5,7 +10,7 @@ def test_convert_records_to_csv(sample_records, monkeypatch):
     """Convert basic sample records to CSV format with proper headers and data."""
     monkeypatch.setattr("sys.platform", "linux")
 
-    result = records_to_csv(sample_records)
+    result = records_to_csv(sample_records, utc=True)
 
     lines = result.split("\n")
     assert lines[0] == "key\tstart\tstop\ttags\tdescription"
@@ -18,7 +23,7 @@ def test_convert_empty_records_list_to_csv(monkeypatch):
     """Convert empty records list to CSV with only headers."""
     monkeypatch.setattr("sys.platform", "linux")
 
-    result = records_to_csv([])
+    result = records_to_csv([], utc=True)
 
     assert result == "key\tstart\tstop\ttags\tdescription"
 
@@ -27,7 +32,7 @@ def test_convert_completed_records_to_csv(completed_records, monkeypatch):
     """Convert basic sample records to CSV format with proper headers and data."""
     monkeypatch.setattr("sys.platform", "linux")
 
-    result = records_to_csv(completed_records)
+    result = records_to_csv(completed_records, utc=True)
 
     lines = result.split("\n")
     assert lines[0] == "key\tstart\tstop\ttags\tdescription"
@@ -39,7 +44,7 @@ def test_convert_running_record_to_csv(running_records, monkeypatch):
     """Convert running record to CSV with empty stop time."""
     monkeypatch.setattr("sys.platform", "linux")
 
-    result = records_to_csv(running_records)
+    result = records_to_csv(running_records, utc=True)
 
     lines = result.split("\n")
     assert lines[0] == "key\tstart\tstop\ttags\tdescription"
@@ -52,7 +57,7 @@ def test_convert_records_with_whitespace_cleanup(monkeypatch):
 
     records = [{"key": "test\t\nkey", "t1": 1640995200, "t2": 1640998800, "_running": False, "ds": "Description\twith\n\nmultiple   spaces"}]
 
-    result = records_to_csv(records)
+    result = records_to_csv(records, utc=True)
 
     lines = result.split("\n")
     assert "test key" in lines[1]  # Tab and newline should be replaced with single space
@@ -63,7 +68,7 @@ def test_use_windows_newlines_on_windows_platform(sample_records, monkeypatch):
     """Use Windows newlines when running on Windows platform."""
     monkeypatch.setattr("sys.platform", "win32")
 
-    result = records_to_csv(sample_records)
+    result = records_to_csv(sample_records, utc=True)
 
     assert "\r\n" in result
     assert result.count("\r\n") == 3  # Header + 3 data lines = 3 newlines
@@ -73,7 +78,7 @@ def test_use_unix_newlines_on_non_windows_platform(sample_records, monkeypatch):
     """Use Unix newlines when running on non-Windows platform."""
     monkeypatch.setattr("sys.platform", "linux")
 
-    result = records_to_csv(sample_records)
+    result = records_to_csv(sample_records, utc=True)
 
     assert "\r\n" not in result
     assert result.count("\n") == 3  # Header + 2 data lines = 3 newlines
@@ -85,7 +90,7 @@ def test_handle_records_with_zero_timestamps(monkeypatch):
 
     records = [{"key": "zero_time", "t1": 0, "t2": 0, "_running": False, "ds": "Zero timestamp test"}]
 
-    result = records_to_csv(records)
+    result = records_to_csv(records, utc=True)
 
     lines = result.split("\n")
     assert "1970-01-01T00:00:00Z" in lines[1]  # Unix epoch
@@ -97,7 +102,7 @@ def test_convert_records_without_tags_in_description(monkeypatch):
 
     records = [{"key": "no_tags", "t1": 1640995200, "t2": 1640998800, "_running": False, "ds": "Simple description without tags"}]
 
-    result = records_to_csv(records)
+    result = records_to_csv(records, utc=True)
 
     lines = result.split("\n")
     fields = lines[1].split("\t")
@@ -110,7 +115,7 @@ def test_convert_single_record_to_csv(monkeypatch):
 
     record = {"key": "single", "t1": 1640995200, "t2": 1640998800, "ds": "Single record #test", "_running": False, "_duration": 3600}
 
-    result = records_to_csv([record])
+    result = records_to_csv([record], utc=True)
 
     lines = result.split("\n")
     assert len(lines) == 2  # Header + 1 data line
@@ -121,7 +126,7 @@ def test_preserve_field_order_in_csv_output(sample_records, monkeypatch):
     """Preserve correct field order in CSV output."""
     monkeypatch.setattr("sys.platform", "linux")
 
-    result = records_to_csv(sample_records)
+    result = records_to_csv(sample_records, utc=True)
 
     lines = result.split("\n")
     header_fields = lines[0].split("\t")
@@ -130,3 +135,257 @@ def test_preserve_field_order_in_csv_output(sample_records, monkeypatch):
     # Verify data fields match header order
     data_fields = lines[1].split("\t")
     assert len(data_fields) == 5
+
+
+@pytest.mark.parametrize(
+    "local_timezone",
+    [
+        timezone.utc,  # UTC
+        ZoneInfo("America/New_York"),  # EST (UTC-5)
+        ZoneInfo("Asia/Tokyo"),  # JST (UTC+9)
+    ],
+)
+def test_utc_true_always_outputs_utc_regardless_of_local_timezone(monkeypatch, local_timezone):
+    """Verify utc=True always outputs UTC timestamps with 'Z' suffix regardless of local timezone."""
+    monkeypatch.setattr("sys.platform", "linux")
+
+    records = [
+        {
+            "key": "test123",
+            "t1": 1640995200,  # 2022-01-01 00:00:00 UTC
+            "t2": 1640998800,  # 2022-01-01 01:00:00 UTC
+            "ds": "Test record #test",
+            "_running": False,
+        }
+    ]
+
+    # Mock datetime.now() with the specified local timezone
+    mock_dt = datetime(2022, 1, 1, 12, 0, 0, tzinfo=local_timezone)
+    monkeypatch.setattr(
+        "better_timetagger_cli.lib.csv.datetime",
+        type(
+            "MockDatetime",
+            (),
+            {
+                "fromtimestamp": lambda ts, tz: datetime.fromtimestamp(ts, tz=tz),
+                "now": lambda: mock_dt,
+            },
+        ),
+    )
+
+    result = records_to_csv(records, utc=True)
+    lines = result.split("\n")
+
+    # Should always output UTC timestamps with 'Z' suffix regardless of local timezone
+    assert "2022-01-01T00:00:00Z" in lines[1]
+    assert "2022-01-01T01:00:00Z" in lines[1]
+
+
+@pytest.mark.parametrize(
+    "timezone_name,expected_start,expected_stop",
+    [
+        ("America/New_York", "2021-12-31T19:00:00-05:00", "2021-12-31T20:00:00-05:00"),  # EST (UTC-5)
+        ("Asia/Tokyo", "2022-01-01T09:00:00+09:00", "2022-01-01T10:00:00+09:00"),  # JST (UTC+9)
+        ("Europe/Paris", "2022-01-01T01:00:00+01:00", "2022-01-01T02:00:00+01:00"),  # CET (UTC+1)
+    ],
+)
+def test_utc_false_outputs_local_timezone(monkeypatch, timezone_name, expected_start, expected_stop):
+    """Verify utc=False outputs timestamps in the specified local timezone."""
+    monkeypatch.setattr("sys.platform", "linux")
+
+    records = [
+        {
+            "key": "test123",
+            "t1": 1640995200,  # 2022-01-01 00:00:00 UTC
+            "t2": 1640998800,  # 2022-01-01 01:00:00 UTC
+            "ds": "Test record #test",
+            "_running": False,
+        }
+    ]
+
+    # Mock datetime.now() to return the specified timezone
+    tz = ZoneInfo(timezone_name)
+    mock_dt = datetime(2022, 1, 1, 12, 0, 0, tzinfo=tz)
+
+    # Create a mock that properly handles the .astimezone() call
+    class MockNowResult:
+        def astimezone(self):
+            return mock_dt
+
+    class MockDatetime:
+        @staticmethod
+        def fromtimestamp(ts, tz):
+            return datetime.fromtimestamp(ts, tz=tz)
+
+        @staticmethod
+        def now():
+            return MockNowResult()
+
+    monkeypatch.setattr("better_timetagger_cli.lib.csv.datetime", MockDatetime)
+
+    result = records_to_csv(records, utc=False)
+    lines = result.split("\n")
+
+    assert expected_start in lines[1]
+    assert expected_stop in lines[1]
+
+
+def test_utc_false_different_outputs_across_timezones(monkeypatch):
+    """Verify utc=False produces different outputs for different local timezones."""
+    monkeypatch.setattr("sys.platform", "linux")
+
+    records = [
+        {
+            "key": "test123",
+            "t1": 1640995200,  # 2022-01-01 00:00:00 UTC
+            "t2": 1640998800,  # 2022-01-01 01:00:00 UTC
+            "ds": "Test record #test",
+            "_running": False,
+        }
+    ]
+
+    # Get result in EST
+    est_tz = ZoneInfo("America/New_York")
+    mock_dt_est = datetime(2022, 1, 1, 12, 0, 0, tzinfo=est_tz)
+
+    class MockNowResultEST:
+        def astimezone(self):
+            return mock_dt_est
+
+    class MockDatetimeEST:
+        @staticmethod
+        def fromtimestamp(ts, tz):
+            return datetime.fromtimestamp(ts, tz=tz)
+
+        @staticmethod
+        def now():
+            return MockNowResultEST()
+
+    monkeypatch.setattr("better_timetagger_cli.lib.csv.datetime", MockDatetimeEST)
+    result_est = records_to_csv(records, utc=False)
+
+    # Get result in JST
+    jst_tz = ZoneInfo("Asia/Tokyo")
+    mock_dt_jst = datetime(2022, 1, 1, 12, 0, 0, tzinfo=jst_tz)
+
+    class MockNowResultJST:
+        def astimezone(self):
+            return mock_dt_jst
+
+    class MockDatetimeJST:
+        @staticmethod
+        def fromtimestamp(ts, tz):
+            return datetime.fromtimestamp(ts, tz=tz)
+
+        @staticmethod
+        def now():
+            return MockNowResultJST()
+
+    monkeypatch.setattr("better_timetagger_cli.lib.csv.datetime", MockDatetimeJST)
+    result_jst = records_to_csv(records, utc=False)
+
+    # Get result in CET
+    cet_tz = ZoneInfo("Europe/Paris")
+    mock_dt_cet = datetime(2022, 1, 1, 12, 0, 0, tzinfo=cet_tz)
+
+    class MockNowResultCET:
+        def astimezone(self):
+            return mock_dt_cet
+
+    class MockDatetimeCET:
+        @staticmethod
+        def fromtimestamp(ts, tz):
+            return datetime.fromtimestamp(ts, tz=tz)
+
+        @staticmethod
+        def now():
+            return MockNowResultCET()
+
+    monkeypatch.setattr("better_timetagger_cli.lib.csv.datetime", MockDatetimeCET)
+    result_cet = records_to_csv(records, utc=False)
+
+    # All results should be different when utc=False
+    assert result_est != result_jst
+    assert result_jst != result_cet
+    assert result_est != result_cet
+
+
+def test_utc_parameter_defaults_to_false(monkeypatch):
+    """Verify that utc parameter defaults to False (local time)."""
+    monkeypatch.setattr("sys.platform", "linux")
+
+    records = [
+        {
+            "key": "test123",
+            "t1": 1640995200,
+            "t2": 1640998800,
+            "ds": "Test record #test",
+            "_running": False,
+        }
+    ]
+
+    # Mock a non-UTC timezone
+    mock_dt = datetime(2022, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("America/New_York"))
+    monkeypatch.setattr(
+        "better_timetagger_cli.lib.csv.datetime",
+        type(
+            "MockDatetime",
+            (),
+            {
+                "fromtimestamp": lambda ts, tz: datetime.fromtimestamp(ts, tz=tz),
+                "now": lambda: mock_dt,
+            },
+        ),
+    )
+
+    # Call without utc parameter
+    result_default = records_to_csv(records)
+    # Call with utc=False explicitly
+    result_false = records_to_csv(records, utc=False)
+
+    # Both should produce the same output
+    assert result_default == result_false
+
+
+def test_utc_false_handles_running_records_correctly(monkeypatch):
+    """Verify utc=False handles running records (empty stop time) correctly."""
+    monkeypatch.setattr("sys.platform", "linux")
+
+    records = [
+        {
+            "key": "running123",
+            "t1": 1640995200,  # 2022-01-01 00:00:00 UTC
+            "t2": 1640995200,
+            "ds": "Running task #task",
+            "_running": True,
+        }
+    ]
+
+    # Mock JST timezone
+    jst_tz = ZoneInfo("Asia/Tokyo")
+    mock_dt_jst = datetime(2022, 1, 1, 12, 0, 0, tzinfo=jst_tz)
+
+    # Create a mock that properly handles the .astimezone() call
+    class MockNowResult:
+        def astimezone(self):
+            return mock_dt_jst
+
+    class MockDatetime:
+        @staticmethod
+        def fromtimestamp(ts, tz):
+            return datetime.fromtimestamp(ts, tz=tz)
+
+        @staticmethod
+        def now():
+            return MockNowResult()
+
+    monkeypatch.setattr("better_timetagger_cli.lib.csv.datetime", MockDatetime)
+
+    result = records_to_csv(records, utc=False)
+    lines = result.split("\n")
+
+    # Start time should be in JST
+    assert "2022-01-01T09:00:00+09:00" in lines[1]
+    # Stop time should be empty for running records
+    fields = lines[1].split("\t")
+    assert fields[2] == ""  # stop field should be empty


### PR DESCRIPTION
This pull request adds support for exporting timestamps in either UTC or local time in the CSV export functionality of the CLI, controlled by a new `--utc` flag. It also introduces comprehensive tests to verify correct timestamp formatting across different time zones and when using the new flag. The main changes include updating the CLI, refactoring CSV timestamp rendering logic, and expanding test coverage.

**CLI and CSV Export Enhancements:**

* Added a `--utc` flag to the `export` CLI command, allowing users to choose whether exported timestamps are in UTC or local time. [[1]](diffhunk://#diff-bce4f0ffe0a8b0d5ae1d549bdb2b315e92291339a596325d1665a0985f993e7cR31-R37) [[2]](diffhunk://#diff-bce4f0ffe0a8b0d5ae1d549bdb2b315e92291339a596325d1665a0985f993e7cR80)
* Updated the `records_to_csv` function and its call sites to accept a `utc` parameter, and refactored timestamp rendering into a new `render_csv_timestamp` helper for clarity and reuse. [[1]](diffhunk://#diff-b79ee86f74a5931d7162ebeee6ef1e34d679ed5042266dbe5dbc32df5c569657L10-R46) [[2]](diffhunk://#diff-b79ee86f74a5931d7162ebeee6ef1e34d679ed5042266dbe5dbc32df5c569657L37-R59) [[3]](diffhunk://#diff-bce4f0ffe0a8b0d5ae1d549bdb2b315e92291339a596325d1665a0985f993e7cL121-R129)

**Testing Improvements:**

* Modified all existing tests for `records_to_csv` to use the new `utc` parameter, ensuring consistent behavior and coverage for UTC output. [[1]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551R1-R13) [[2]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L21-R26) [[3]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L30-R35) [[4]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L42-R47) [[5]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L55-R60) [[6]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L66-R71) [[7]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L76-R81) [[8]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L88-R93) [[9]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L100-R105) [[10]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L113-R118) [[11]](diffhunk://#diff-0071586ab006d462e1a8c4d30cdd1f598002935387b444693b1c5ee17aaf5551L124-R129)
* Added extensive new parameterized and functional tests to verify that:
  - UTC output is always in UTC regardless of local system timezone.
  - Local time output reflects the correct local timezone.
  - Output differs across time zones when not using UTC.
  - The default behavior remains local time if `utc` is not specified.
  - Running records are handled correctly with respect to timestamp fields.

These changes improve the flexibility and reliability of CSV exports, especially for users working across multiple time zones.